### PR TITLE
Remove --block flag

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -16,4 +16,4 @@ if [ -n "${JSON}" ]; then
   fi
 fi
 
-rainbow --update-stack-if-exists -v -r ${AWS_REGION:-ap-southeast-2} ${PARAMS} --block ${STACKNAME} stack.json "$@"
+rainbow --update-stack-if-exists -v -r ${AWS_REGION:-ap-southeast-2} ${PARAMS} ${STACKNAME} stack.json "$@"


### PR DESCRIPTION
I think the best way is to revert the changes and remove `--block` in `deploy.sh`

In Nika's deploy script, this parameter can be passed in and Rainbow will understand it.

e.g. if you want it to iterate.

`docker run -v stack.json:/app/stack.json -v params.json:/app/params.json -e rewardle/deployer mystackname --block`
