### PR TITLE
updated serverless to 1.25.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN curl -sL https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh
   &&  bash /tmp/install_nvm.sh -D=$NVM_DIR \
   && . ~/.bashrc \
   && nvm install $NODE_6_VERSION \
-  && npm install serverless@1.20.2 -g \
+  && npm install serverless@1.25.0 -g \
   && nvm install $NODE_4_VERSION \
   && nvm alias default $NODE_6_VERSION \
   && ln -s /usr/local/nvm/versions/node/v6.10.0/bin/npm /usr/bin/npm \


### PR DESCRIPTION
update serverless to 1.25.0.

I have tested against email service. There should be no breaking changes as suggested by their docs.

will have to update other serverless.yml's to lift version restriction with `>=1.20.2`.